### PR TITLE
implement nix derivations for building with CMake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+{ nixpkgs ? import <nixpkgs> { } }:
+with nixpkgs;
+stdenv.mkDerivation rec {
+  pname = "ft_IRC";
+  version = "0.0.0";
+
+  src = ./.;
+
+  buildInputs = [ pkgs.cmake ];
+
+  configurePhase = ''
+    cmake .
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv bin/ft_IRC $out/bin
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1606309800,
+        "narHash": "sha256-tqWetEc8h4EChS+ddrpJSnLbZ6cX4RfdsTa2XivElI0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9518fac712ca001009bd12a3c94621f1ee805657",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-20.03",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "ft_IRC";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-20.03";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems =
+        [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in {
+
+      packages = forAllSystems (system:
+        let
+          drv = import ./default.nix {
+            nixpkgs = import nixpkgs { system = system; };
+          };
+        in { ft-irc = drv; });
+
+      defaultPackage = forAllSystems (system: self.packages."${system}".ft-irc);
+
+      defaultApp = forAllSystems (system: {
+        type = "app";
+        program = "${self.defaultPackage."${system}"}/bin/ft_IRC";
+      });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  buildInputs = [
+
+    pkgs.cmake
+    pkgs.clang
+
+  ];
+}


### PR DESCRIPTION
This implements the basic machinery to get the project building healthily with CMake and nix. Nix will cover all of the dependencies (in the future, we don't have any now!) and make sure it knows how to get CMake for your system.