### PR TITLE
add move semantics to mutexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 
-set (CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wunreachable-code -fsanitize=address -g")
+set (CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wunreachable-code -fsanitize=address -g -pthread")
 
 add_subdirectory(shared_lib)
 add_subdirectory(tcp_lib)

--- a/shared_lib/tests/Mutex_test.cpp
+++ b/shared_lib/tests/Mutex_test.cpp
@@ -64,3 +64,18 @@ TEST(MutexTest, Printing)
     stream2 << mtx;
     ASSERT_EQ(stream2.str(), "Mutex(<<locked>>)");
 }
+
+TEST(MutexTaste, Moving)
+{
+    ft_irc::Mutex<int> mtx1 = ft_irc::MakeMutex<int>(42);
+
+    ft_irc::Mutex<int> mtx2 = std::move(mtx1); // move operator
+
+    ft_irc::Mutex<int> mtx3 = ft_irc::MakeMutex<int>(1337);
+
+    mtx3 = std::move(mtx2); // move assignment operator
+
+    auto h = mtx3.Take();
+    ASSERT_EQ(*h, 42);
+}
+


### PR DESCRIPTION
This PR changes a lot of things about mutexes, they work the same, however now they allow for moving mutexes. This means the underlying mutex now lives in a `unique_ptr`. This comes at a (relatively) tiny runtime cost, but the tradeoff is worth it in most scenarios (specifically) those which have large(r) amounts of data in the mutex. A few corners have been cut (on purpose) for allowing minimal cost while keeping safety 100% (hopefully.)